### PR TITLE
Add GitHub workflows for Maven based build and release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,30 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Publish to cdoc2-capsule-server GitHub Packages Apache Maven (Maven repository)
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy -f cdoc2-server/ -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         cache: maven
 
     - name: Build with Maven
-      run: mvn -B package --file cdoc2-server/pom.xml
+      run: mvn -B verify --file cdoc2-server/pom.xml
       env:
         GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,44 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build cdoc2-capsule-server with CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  ACTIONS_STEP_DEBUG: true
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        overwrite-settings: true #generate settings.xml
+        cache: maven
+
+    - name: Build with Maven
+      run: mvn -B package --file cdoc2-server/pom.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
+
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    #- name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ See [admin-guide.md](cdoc2-server/admin-guide.md) for running
 
 See [VERSIONING.md](https://github.com/open-eid/cdoc2-java-ref-impl/blob/master/VERSIONING.md)
 
+### GitHub release
+
+[Create release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) on tag done by VERSIONING.md process. It will trigger `maven-release.yml` workflow that
+will deploy Maven packages to GitHub Maven package repository.
+
+
 ## Related projects
 
 * Gatling tests (load and functional) for cdoc2-capsule-server https://github.com/open-eid/cdoc2-gatling-tests 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ and [DigiDoc4-Client](https://github.com/open-eid/DigiDoc4-Client) for CDOC2 enc
   - server-common       - shared common server code
   - server-openapi      - server stub generation from OpenAPI specifications
   - cdoc2-shared-crypto - some shared crypto functions
-* gatling-tests  - Functional and load tests for cdoc2-server. TODO: move to separate repo (in progress)
 
 ## Preconditions for building
 * Java 17
@@ -54,6 +53,8 @@ https://stackoverflow.com/questions/63041402/github-packages-single-maven-reposi
 So defining single Maven package repo from `open-eid` is enough for pulling cdoc2-* dependencies.
 
 ## Building & Running
+
+[![Build cdoc2-capsule-server with CI](https://github.com/open-eid/cdoc2-capsule-server/actions/workflows/maven.yml/badge.svg)](https://github.com/open-eid/cdoc2-capsule-server/actions/workflows/maven.yml)
 
 ```bash
 cd cdoc2-server

--- a/cdoc2-server/get-server/pom.xml
+++ b/cdoc2-server/get-server/pom.xml
@@ -35,23 +35,6 @@
 		<logback.version>1.5.6</logback.version>
 	</properties>
 
-    <!--repositories>
-        <repository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/40/packages/maven</url>
-        </repository>
-    </repositories-->
-
-    <!--distributionManagement>
-        <repository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-        </repository>
-        <snapshotRepository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-        </snapshotRepository>
-    </distributionManagement-->
 
 	<profiles>
 		<profile>
@@ -89,7 +72,21 @@
 					<!--suppress UnresolvedMavenProperty -->
 					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
 				</repository>
+
 			</repositories>
+			<distributionManagement>
+				<repository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</repository>
+				<snapshotRepository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</snapshotRepository>
+			</distributionManagement>
+
 		</profile>
 
 		<profile>
@@ -107,18 +104,17 @@
 			<distributionManagement>
 				<!-- env variables are available, when run by gitlab CI -->
 				<repository>
-					<id>gitlab.ext.cyber.ee</id>
+					<id>${env.CI_SERVER_HOST}</id>
 					<!--suppress UnresolvedMavenProperty -->
 					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
 				</repository>
 				<snapshotRepository>
-					<id>gitlab.ext.cyber.ee</id>
+					<id>${env.CI_SERVER_HOST}</id>
 					<!--suppress UnresolvedMavenProperty -->
 					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
 				</snapshotRepository>
 			</distributionManagement>
 		</profile>
-
 	</profiles>
 
 	<dependencies>
@@ -137,7 +133,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-server-db</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.0-SNAPSHOT</version>
 		</dependency>
 
 
@@ -151,7 +147,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -230,7 +226,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.0-SNAPSHOT</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -347,6 +343,7 @@
 				<configuration>
 					<trimStackTrace>false</trimStackTrace>
 					<groups>${tests}</groups>
+					<!--suppress UnresolvedMavenProperty -->
 					<argLine>${argLine}</argLine>
 				</configuration>
 			</plugin>
@@ -401,6 +398,32 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+
+			<!-- if exact RELEASE version of module already exists, -->
+			<!-- then skip deployment by setting maven.deploy.skip=true property for that module -->
+			<!-- GitHub doesn't allow overwriting existing RELEASE modules and deploy will fail with HTTP 409 -->
+			<plugin>
+				<groupId>org.honton.chas</groupId>
+				<artifactId>exists-maven-plugin</artifactId>
+				<version>0.13.0</version>
+				<executions>
+					<execution>
+						<phase>install</phase>
+						<goals>
+							<goal>remote</goal>
+						</goals>
+						<configuration>
+							<!-- run only if deploy goal is specified in maven command line -->
+							<requireGoal>deploy</requireGoal>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<failIfNotMatch>false</failIfNotMatch>
+					<userProperty>true</userProperty>
+					<!--skip>true</skip-->
+				</configuration>
 			</plugin>
 
 		</plugins>

--- a/cdoc2-server/get-server/pom.xml
+++ b/cdoc2-server/get-server/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -226,7 +226,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/cdoc2-server/get-server/pom.xml
+++ b/cdoc2-server/get-server/pom.xml
@@ -121,7 +121,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-shared-crypto</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/cdoc2-server/pom.xml
+++ b/cdoc2-server/pom.xml
@@ -4,7 +4,7 @@
 
 	<artifactId>cdoc2-server</artifactId>
 	<groupId>ee.cyber.cdoc2</groupId>
-	<version>1.3.1</version>
+	<version>1.4.0-SNAPSHOT</version>
 
 	<description>CDOC2 server pom</description>
 
@@ -43,54 +43,71 @@
 		<spring.version>6.1.6</spring.version>
 
   	</properties>
+
 	<profiles>
-	<profile>
-		<!-- activate github profile when run by github actions -->
-		<id>github_ci</id>
-		<activation>
-			<property>
-				<name>env.GITHUB_ACTIONS</name>
-				<value>true</value>
-			</property>
-		</activation>
-		<repositories>
-			<repository>
-				<!-- must have matching server.id in settings.xml -->
-				<!-- github actions/checkout default for server-id is "github"-->
-				<id>github</id>
-				<!-- When pulling, the package index is based on the organization level, not the repository level. -->
-				<!-- Although GITHUB_REPOSITORY contains repo, all organization packages are indexed there -->
-				<!-- https://stackoverflow.com/questions/63041402/github-packages-single-maven-repository-for-github-organization -->
-				<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
-			</repository>
-		</repositories>
-	</profile>
+		<profile>
+			<!-- activate github profile when run by github actions -->
+			<id>github_ci</id>
+			<activation>
+				<property>
+					<name>env.GITHUB_ACTIONS</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<repositories>
+				<repository>
+					<!-- must have matching server.id in settings.xml -->
+					<!-- github actions/checkout default for server-id is "github"-->
+					<id>github</id>
+					<!-- When pulling, the package index is based on the organization level, not the repository level. -->
+					<!-- Although GITHUB_REPOSITORY contains repo, all organization packages are indexed there -->
+					<!-- https://stackoverflow.com/questions/63041402/github-packages-single-maven-repository-for-github-organization -->
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</repository>
 
-	<profile>
-		<!-- set gitlab.ext profile active when run by gitlab CI -->
-		<id>gitlab_ci</id>
-		<activation>
-			<property>
-				<name>env.GITLAB_CI</name>
-				<value>true</value>
-			</property>
-		</activation>
-		<!-- repositories are configured in settings.xml -->
-		<!--repositories></repositories-->
+			</repositories>
+			<distributionManagement>
+				<repository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</repository>
+				<snapshotRepository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</snapshotRepository>
+			</distributionManagement>
 
-		<distributionManagement>
-			<!-- env variables are available, when run by gitlab CI -->
-			<repository>
-				<id>gitlab.ext.cyber.ee</id>
-				<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
-			</repository>
-			<snapshotRepository>
-				<id>gitlab.ext.cyber.ee</id>
-				<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
-			</snapshotRepository>
-		</distributionManagement>
-	</profile>
-	</profiles>
+		</profile>
+
+		<profile>
+			<!-- set gitlab.ext profile active when run by gitlab CI -->
+			<id>gitlab_ci</id>
+			<activation>
+				<property>
+					<name>env.GITLAB_CI</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<!-- repositories are configured in settings.xml -->
+			<!--repositories></repositories-->
+
+			<distributionManagement>
+				<!-- env variables are available, when run by gitlab CI -->
+				<repository>
+					<id>${env.CI_SERVER_HOST}</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+				</repository>
+				<snapshotRepository>
+					<id>${env.CI_SERVER_HOST}</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+				</snapshotRepository>
+			</distributionManagement>
+		</profile>	</profiles>
 
 	<dependencyManagement>
 		<dependencies>
@@ -217,13 +234,36 @@
 				</executions>
 			</plugin>
 
+			<!-- if exact RELEASE version of module already exists, -->
+			<!-- then skip deployment by setting maven.deploy.skip=true property for that module -->
+			<!-- GitHub doesn't allow overwriting existing RELEASE modules and deploy will fail with HTTP 409 -->
+			<plugin>
+				<groupId>org.honton.chas</groupId>
+				<artifactId>exists-maven-plugin</artifactId>
+				<version>0.13.0</version>
+				<executions>
+					<execution>
+						<phase>install</phase>
+						<goals>
+							<goal>remote</goal>
+						</goals>
+						<configuration>
+							<!-- run only if deploy goal is specified in maven command line -->
+							<requireGoal>deploy</requireGoal>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<failIfNotMatch>false</failIfNotMatch>
+					<userProperty>true</userProperty>
+					<!--skip>true</skip-->
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>3.1.1</version>
-				<configuration>
-					<skip>false</skip>
-				</configuration>
 			</plugin>
 
 		</plugins>

--- a/cdoc2-server/put-server/pom.xml
+++ b/cdoc2-server/put-server/pom.xml
@@ -153,14 +153,14 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.5.0-SNAPSHOT</version>
+			<version>1.4.0</version>
 			<!-- cdoc2-lib src/test compiled classes-->
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/cdoc2-server/put-server/pom.xml
+++ b/cdoc2-server/put-server/pom.xml
@@ -71,7 +71,21 @@
 					<!--suppress UnresolvedMavenProperty -->
 					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
 				</repository>
+
 			</repositories>
+			<distributionManagement>
+				<repository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</repository>
+				<snapshotRepository>
+					<id>github</id>
+					<!--suppress UnresolvedMavenProperty -->
+					<url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+				</snapshotRepository>
+			</distributionManagement>
+
 		</profile>
 
 		<profile>
@@ -89,22 +103,20 @@
 			<distributionManagement>
 				<!-- env variables are available, when run by gitlab CI -->
 				<repository>
-					<id>gitlab.ext.cyber.ee</id>
+					<id>${env.CI_SERVER_HOST}</id>
 					<!--suppress UnresolvedMavenProperty -->
 					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
 				</repository>
 				<snapshotRepository>
-					<id>gitlab.ext.cyber.ee</id>
+					<id>${env.CI_SERVER_HOST}</id>
 					<!--suppress UnresolvedMavenProperty -->
 					<url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
 				</snapshotRepository>
 			</distributionManagement>
 		</profile>
-
 	</profiles>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-shared-crypto</artifactId>
@@ -127,7 +139,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-server-db</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -141,14 +153,14 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-lib</artifactId>
-			<version>1.4.0</version>
+			<version>1.5.0-SNAPSHOT</version>
 			<!-- cdoc2-lib src/test compiled classes-->
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -383,6 +395,33 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- if exact RELEASE version of module already exists, -->
+			<!-- then skip deployment by setting maven.deploy.skip=true property for that module -->
+			<!-- GitHub doesn't allow overwriting existing RELEASE modules and deploy will fail with HTTP 409 -->
+			<plugin>
+				<groupId>org.honton.chas</groupId>
+				<artifactId>exists-maven-plugin</artifactId>
+				<version>0.13.0</version>
+				<executions>
+					<execution>
+						<phase>install</phase>
+						<goals>
+							<goal>remote</goal>
+						</goals>
+						<configuration>
+							<!-- run only if deploy goal is specified in maven command line -->
+							<requireGoal>deploy</requireGoal>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<failIfNotMatch>false</failIfNotMatch>
+					<userProperty>true</userProperty>
+					<!--skip>true</skip-->
+				</configuration>
+			</plugin>
+
 
 		</plugins>
 	</build>

--- a/cdoc2-server/put-server/pom.xml
+++ b/cdoc2-server/put-server/pom.xml
@@ -120,7 +120,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-shared-crypto</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/cdoc2-server/server-common/pom.xml
+++ b/cdoc2-server/server-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>ee.cyber.cdoc2</groupId>
 		<artifactId>cdoc2-server</artifactId>
-		<version>1.3.1</version>
+		<version>1.4.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-server-db</artifactId>
-			<version>2.0.1</version>
+			<version>2.1.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cdoc2-server/server-db/pom.xml
+++ b/cdoc2-server/server-db/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>ee.cyber.cdoc2</groupId>
 		<artifactId>cdoc2-server</artifactId>
-		<version>1.3.1</version>
+		<version>1.4.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 
 	<artifactId>cdoc2-server-db</artifactId>
-	<version>2.0.1</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	
 	<dependencies>

--- a/cdoc2-server/server-db/pom.xml
+++ b/cdoc2-server/server-db/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>ee.cyber.cdoc2</groupId>
 			<artifactId>cdoc2-shared-crypto</artifactId>
-			<version>0.1.0</version>
+			<version>0.2.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/cdoc2-server/server-openapi/pom.xml
+++ b/cdoc2-server/server-openapi/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>ee.cyber.cdoc2</groupId>
         <artifactId>cdoc2-server</artifactId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/cdoc2-shared-crypto/pom.xml
+++ b/cdoc2-shared-crypto/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ee.cyber.cdoc2</groupId>
     <artifactId>cdoc2-shared-crypto</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0-SNAPSHOT</version>
     <description>CDOC2 common crypto functions shared between lib and server</description>
     <packaging>jar</packaging>
 
@@ -20,20 +20,51 @@
         <logback.version>1.5.6</logback.version>
     </properties>
 
-    <!-- upload maven packages, used by maven deploy-->
-    <!-- optionally specify as
-    -DaltDeploymentRepository=gitlab.ext.cyber.ee::https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven
-    -->
-    <distributionManagement>
-        <repository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-        </repository>
-        <snapshotRepository>
-            <id>gitlab.ext.cyber.ee</id>
-            <url>https://gitlab.ext.cyber.ee/api/v4/projects/39/packages/maven</url>
-        </snapshotRepository>
-    </distributionManagement>
+    <profiles>
+        <profile>
+            <!-- activate github profile when run by github actions -->
+            <id>github_ci</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <distributionManagement>
+                <repository>
+                    <id>github</id> <!-- must match server.id in settings.xml -->
+                    <!--suppress UnresolvedMavenProperty -->
+                    <url>https://maven.pkg.github.com/${env.GITHUB_REPOSITORY}</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+
+        <profile>
+            <!-- set gitlab profile active when run by gitlab CI -->
+            <id>gitlab_ci</id>
+            <activation>
+                <property>
+                    <name>env.GITLAB_CI</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <distributionManagement>
+                <!-- env variables are available, when run by gitlab CI -->
+                <repository>
+                    <id>${env.CI_SERVER_HOST}</id>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+                </repository>
+                <snapshotRepository>
+                    <id>${env.CI_SERVER_HOST}</id>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <url>${env.CI_SERVER_URL}/api/v4/projects/${env.CI_PROJECT_ID}/packages/maven</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+    </profiles>
 
     <dependencies>
 
@@ -51,5 +82,36 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- if exact RELEASE version of module already exists, -->
+            <!-- then skip deployment by setting maven.deploy.skip=true property for that module -->
+            <!-- GitHub doesn't allow overwriting existing RELEASE modules and deploy will fail with HTTP 409 -->
+            <plugin>
+                <groupId>org.honton.chas</groupId>
+                <artifactId>exists-maven-plugin</artifactId>
+                <version>0.13.0</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>remote</goal>
+                        </goals>
+                        <configuration>
+                            <!-- run only if deploy goal is specified in maven command line -->
+                            <requireGoal>deploy</requireGoal>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failIfNotMatch>false</failIfNotMatch>
+                    <userProperty>true</userProperty>
+                    <!--skip>true</skip-->
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
* Added .github/workflows/maven.yml for building on GH CI - [test run](https://github.com/jann0k/cdoc2-capsule-server/actions/runs/10318329456)
* Added .github/workflows/maven-release.yml for releasing - [test run](https://github.com/jann0k/cdoc2-capsule-server/actions/runs/10318094182)
* Update pom.xml files to support building with CI