### PR TITLE
GitHub workflow action: create docker images on release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,10 +31,8 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          #registry: ${{ env.REGISTRY }}
           registry: ghcr.io
           username: ${{ github.actor }}
-          #password: ${{ secrets.GITHUB_TOKEN }}
           password: ${{ github.token }}
 
       # Fail fast if compilation fails without downloading all docker images
@@ -53,7 +51,7 @@ jobs:
             -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=${REGISTRY}/cdoc2/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+            -Dspring-boot.build-image.imageName=${REGISTRY}/jann0k/cdoc2-put-server:${TAG}-${GITHUB_SHA}
 
         env:
           REGISTRY: ghcr.io

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
           mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
-            -f put-server
+            -f put-server \
             -Dmaven.test.skip=true \
             -Dspring-boot.build-image.publish=true \
             -Ddocker.publishRegistry.url=ghcr.io \

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -15,6 +15,7 @@ jobs:
       packages: write
 
     steps:
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -22,10 +23,10 @@ jobs:
           distribution: 'temurin'
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-      - name: Publish to GitHub Packages Apache Maven
-        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+#      - name: Publish to GitHub Packages Apache Maven
+#        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+#        env:
+#          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Set up JDK 17
-
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -9,22 +9,52 @@ on:
 
 jobs:
   publish:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+
         with:
           java-version: '17'
           distribution: 'temurin'
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Publish to GitHub Packages Apache Maven
+        uses: actions/setup-java@v4
         run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          #registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          #password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ github.token }}
+
+      - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
+        uses: actions/setup-java@v4
+        run: |
+          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
+            -f put-server
+            -Dmaven.test.skip=true \
+            -Dspring-boot.build-image.publish=true \
+            -Ddocker.publishRegistry.url=ghcr.io \
+            -Ddocker.publishRegistry.username=${USERNAME} \
+            -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
+            -Dspring-boot.build-image.imageName=cdoc2/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+
+        #Note: imageName tag is built from git tag which can be different from module version
+        env:
+          USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
+          # Note: git tag can contain more symbols than Container registry, allowed for docker tag:
+          # lowercase and uppercase letters, digits, underscores, periods, and hyphens.
+          TAG: ${{ github.event.release.tag_name }}
+
+

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,11 +38,11 @@ jobs:
           password: ${{ github.token }}
 
       # Fail fast if compilation fails without downloading all docker images
-      - name: Install packages (temp)
-        run: mvn install -s $GITHUB_WORKSPACE/settings.xml -Dmaven.test.skip=true
-        env:
-          MAVEN_REPO: open-eid/cdoc2-capsule-server
-          GITHUB_TOKEN: ${{ github.token }}
+#      - name: Install packages (temp)
+#        run: mvn install -s $GITHUB_WORKSPACE/settings.xml -Dmaven.test.skip=true
+#        env:
+#          MAVEN_REPO: open-eid/cdoc2-capsule-server
+#          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
@@ -50,19 +50,20 @@ jobs:
             -f put-server \
             -Dmaven.test.skip=true \
             -Dspring-boot.build-image.publish=true \
-            -Ddocker.publishRegistry.url=ghcr.io \
+            -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=cdoc2/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+            -Dspring-boot.build-image.imageName=${REGISTRY}/cdoc2/cdoc2-put-server:${TAG}-${GITHUB_SHA}
 
-        #Note: imageName tag is built from git tag which can be different from module version
         env:
+          REGISTRY: ghcr.io
           USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
           # Note: git tag can contain more symbols than Container registry, allowed for docker tag:
           # lowercase and uppercase letters, digits, underscores, periods, and hyphens.
+          # Note: imageName tag is built from git tag which can be different from module version
           TAG: ${{ github.event.release.tag_name }}
-          #force usage of open-eid repo
+          #force usage of open-eid Maven repo
           MAVEN_REPO: open-eid/cdoc2-capsule-server
 
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -54,8 +54,8 @@ jobs:
             -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA}
-
+            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA} \
+            -Dspring-boot.build-image.tags=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:latest
         env:
           REGISTRY: ghcr.io
           USERNAME: ${{ github.actor }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -37,6 +37,13 @@ jobs:
           #password: ${{ secrets.GITHUB_TOKEN }}
           password: ${{ github.token }}
 
+      # Fail fast if compilation fails without downloading all docker images
+      - name: Install packages (temp)
+        run: mvn install -s $GITHUB_WORKSPACE/settings.xml -Dmaven.test.skip=true
+        env:
+          MAVEN_REPO: open-eid/cdoc2-capsule-server
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
           mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
@@ -55,5 +62,7 @@ jobs:
           # Note: git tag can contain more symbols than Container registry, allowed for docker tag:
           # lowercase and uppercase letters, digits, underscores, periods, and hyphens.
           TAG: ${{ github.event.release.tag_name }}
+          #force usage of open-eid repo
+          MAVEN_REPO: open-eid/cdoc2-capsule-server
 
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -23,24 +23,18 @@ jobs:
           distribution: 'temurin'
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-#      - name: Publish to GitHub Packages Apache Maven
-#        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
-#        env:
-#          GITHUB_TOKEN: ${{ github.token }}
+      - name: Publish to GitHub Packages Apache Maven
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
+      # test if username and password are correct (may still fail if no write access or wrong package name)
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-
-      # Fail fast if compilation fails without downloading all docker images
-#      - name: Install packages (temp)
-#        run: mvn install -s $GITHUB_WORKSPACE/settings.xml -Dmaven.test.skip=true
-#        env:
-#          MAVEN_REPO: open-eid/cdoc2-capsule-server
-#          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
@@ -51,7 +45,15 @@ jobs:
             -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=${REGISTRY}/jann0k/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
+            -f get-server \
+            -Dmaven.test.skip=true \
+            -Dspring-boot.build-image.publish=true \
+            -Ddocker.publishRegistry.url=${REGISTRY} \
+            -Ddocker.publishRegistry.username=${USERNAME} \
+            -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
+            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:${TAG}-${GITHUB_SHA}
 
         env:
           REGISTRY: ghcr.io

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -23,7 +23,6 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Publish to GitHub Packages Apache Maven
-        uses: actions/setup-java@v4
         run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -38,7 +37,6 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
-        uses: actions/setup-java@v4
         run: |
           mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
             -f put-server

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,16 +38,16 @@ jobs:
 
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
-          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
-            -f get-server \
+          mvn spring-boot:build-image -f get-server \
+            -s $GITHUB_WORKSPACE/settings.xml \
             -Dmaven.test.skip=true \
             -Dspring-boot.build-image.publish=true \
             -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
             -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:${TAG}-${GITHUB_SHA}
-          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
-            -f put-server \
+          mvn spring-boot:build-image -f put-server \
+            -s $GITHUB_WORKSPACE/settings.xml \
             -Dmaven.test.skip=true \
             -Dspring-boot.build-image.publish=true \
             -Ddocker.publishRegistry.url=${REGISTRY} \
@@ -63,7 +63,7 @@ jobs:
           # lowercase and uppercase letters, digits, underscores, periods, and hyphens.
           # Note: imageName tag is built from git tag which can be different from module version
           TAG: ${{ github.event.release.tag_name }}
-          #force usage of open-eid Maven repo
+          # use open-eid Maven repo for dependencies download, see pom.xml
           MAVEN_REPO: open-eid/cdoc2-capsule-server
 
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -39,14 +39,6 @@ jobs:
       - name: Build Docker/OCI images and publish to GH Container registry (ghcr.io)
         run: |
           mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
-            -f put-server \
-            -Dmaven.test.skip=true \
-            -Dspring-boot.build-image.publish=true \
-            -Ddocker.publishRegistry.url=${REGISTRY} \
-            -Ddocker.publishRegistry.username=${USERNAME} \
-            -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA}
-          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
             -f get-server \
             -Dmaven.test.skip=true \
             -Dspring-boot.build-image.publish=true \
@@ -54,6 +46,14 @@ jobs:
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
             -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:${TAG}-${GITHUB_SHA}
+          mvn spring-boot:build-image -s $GITHUB_WORKSPACE/settings.xml \
+            -f put-server \
+            -Dmaven.test.skip=true \
+            -Dspring-boot.build-image.publish=true \
+            -Ddocker.publishRegistry.url=${REGISTRY} \
+            -Ddocker.publishRegistry.username=${USERNAME} \
+            -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
+            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA}
 
         env:
           REGISTRY: ghcr.io

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -45,7 +45,8 @@ jobs:
             -Ddocker.publishRegistry.url=${REGISTRY} \
             -Ddocker.publishRegistry.username=${USERNAME} \
             -Ddocker.publishRegistry.password=${GITHUB_TOKEN} \
-            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:${TAG}-${GITHUB_SHA}
+            -Dspring-boot.build-image.imageName=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:${TAG}-${GITHUB_SHA} \
+            -Dspring-boot.build-image.tags=${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-get-server:latest
           mvn spring-boot:build-image -f put-server \
             -s $GITHUB_WORKSPACE/settings.xml \
             -Dmaven.test.skip=true \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ by [defining repository variable](https://docs.github.com/en/actions/writing-wor
 
 See [getting-started.md](getting-started.md) and [admin-guide.md](admin-guide.md)
 
+### Running pre-built Docker/OCI images
+
+Download `cdoc2-put-server` and `cdoc2-get-server` images from [open-eid Container registry](https://github.com/open-eid?ecosystem=container&tab=packages)
+
+[ghcr.io login](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
+
+TODO: Configuring Docker images
 
 ## Releasing and versioning
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ See [VERSIONING.md](https://github.com/open-eid/cdoc2-java-ref-impl/blob/master/
 
 ### GitHub release
 
-[Create release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) on tag done by VERSIONING.md process. It will trigger `maven-release.yml` workflow that
-will deploy Maven packages to GitHub Maven package repository.
+[Create release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) on tag done by [VERSIONING.md](https://github.com/open-eid/cdoc2-java-ref-impl/blob/master/VERSIONING.md) process. 
+It will trigger `maven-release.yml` workflow that will deploy Maven packages to GitHub Maven package repository
+and build & publish Docker/OCI images.
 
 
 ## Related projects

--- a/cdoc2-shared-crypto/pom.xml
+++ b/cdoc2-shared-crypto/pom.xml
@@ -111,6 +111,13 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.3</version>
+            </plugin>
+
+
         </plugins>
     </build>
 

--- a/get-server/pom.xml
+++ b/get-server/pom.xml
@@ -417,10 +417,21 @@
 						<env>
 							<BP_JVM_VERSION>${java.version}</BP_JVM_VERSION>
 							<BP_SPRING_CLOUD_BINDINGS_DISABLED>true</BP_SPRING_CLOUD_BINDINGS_DISABLED>
+							<!--suppress UnresolvedMavenProperty -->
 							<BP_DEPENDENCY_MIRROR>${bp.dependency.mirror}</BP_DEPENDENCY_MIRROR>
 							<BPL_SPRING_CLOUD_BINDINGS_DISABLED>true</BPL_SPRING_CLOUD_BINDINGS_DISABLED>
 						</env>
 					</image>
+					<docker>
+						<publishRegistry>
+							<!--suppress UnresolvedMavenProperty -->
+							<url>${docker.publishRegistry.url}</url>
+							<!--suppress UnresolvedMavenProperty -->
+							<username>${docker.publishRegistry.username}</username>
+							<!--suppress UnresolvedMavenProperty -->
+							<password>${docker.publishRegistry.password}</password>
+						</publishRegistry>
+					</docker>
 				</configuration>
 				<executions>
 					<execution>

--- a/get-server/pom.xml
+++ b/get-server/pom.xml
@@ -421,6 +421,8 @@
 							<BP_DEPENDENCY_MIRROR>${bp.dependency.mirror}</BP_DEPENDENCY_MIRROR>
 							<BPL_SPRING_CLOUD_BINDINGS_DISABLED>true</BPL_SPRING_CLOUD_BINDINGS_DISABLED>
 						</env>
+						<!--suppress UnresolvedMavenProperty -->
+						<tags>${spring-boot.build-image.tags}</tags>
 					</image>
 					<docker>
 						<publishRegistry>

--- a/put-server/pom.xml
+++ b/put-server/pom.xml
@@ -416,14 +416,18 @@
 						<env>
 							<BP_JVM_VERSION>${java.version}</BP_JVM_VERSION>
 							<BP_SPRING_CLOUD_BINDINGS_DISABLED>true</BP_SPRING_CLOUD_BINDINGS_DISABLED>
+							<!--suppress UnresolvedMavenProperty -->
 							<BP_DEPENDENCY_MIRROR>${bp.dependency.mirror}</BP_DEPENDENCY_MIRROR>
 							<BPL_SPRING_CLOUD_BINDINGS_DISABLED>true</BPL_SPRING_CLOUD_BINDINGS_DISABLED>
 						</env>
 					</image>
 					<docker>
 						<publishRegistry>
+							<!--suppress UnresolvedMavenProperty -->
 							<url>${docker.publishRegistry.url}</url>
+							<!--suppress UnresolvedMavenProperty -->
 							<username>${docker.publishRegistry.username}</username>
+							<!--suppress UnresolvedMavenProperty -->
 							<password>${docker.publishRegistry.password}</password>
 						</publishRegistry>
 					</docker>

--- a/put-server/pom.xml
+++ b/put-server/pom.xml
@@ -420,6 +420,8 @@
 							<BP_DEPENDENCY_MIRROR>${bp.dependency.mirror}</BP_DEPENDENCY_MIRROR>
 							<BPL_SPRING_CLOUD_BINDINGS_DISABLED>true</BPL_SPRING_CLOUD_BINDINGS_DISABLED>
 						</env>
+						<!--suppress UnresolvedMavenProperty -->
+						<tags>${spring-boot.build-image.tags}</tags>
 					</image>
 					<docker>
 						<publishRegistry>

--- a/put-server/pom.xml
+++ b/put-server/pom.xml
@@ -420,6 +420,13 @@
 							<BPL_SPRING_CLOUD_BINDINGS_DISABLED>true</BPL_SPRING_CLOUD_BINDINGS_DISABLED>
 						</env>
 					</image>
+					<docker>
+						<publishRegistry>
+							<url>${docker.publishRegistry.url}</url>
+							<username>${docker.publishRegistry.username}</username>
+							<password>${docker.publishRegistry.password}</password>
+						</publishRegistry>
+					</docker>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
DONE:
* [put-server/get-server Docker/OCI images built & uploaded](https://github.com/jann0k?ecosystem=container&tab=packages) on [Release](https://github.com/jann0k/cdoc2-capsule-server/releases)
* `latest` tag for built images

Possible improvements:

* [OCI Labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) https://github.com/jann0k/cdoc2-capsule-server/pkgs/container/cdoc2-get-server/268066826?tag=v1.4.0-docker.13-3ade17970f9319a05af818cff40a37797f39fc26 ?
* Instead of re-building from source code, download .jar from Maven package registry or from previous step
* reproducible build (current build adds build.info that contains build time, use https://docs.docker.com/build/ci/github-actions/reproducible-builds/#git-commit-timestamps)

