### PR TITLE
GH workflow: build cdoc2-server-liquibase Docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${TAG}-${GITHUB_SHA}
+          images: ${{ github.actor }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -57,7 +57,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           #subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-name: ${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${TAG}-${GITHUB_SHA}
+          subject-name: ${{ github.actor }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,63 @@
+#
+name: Create and publish a Docker cdoc2-server-liquibase image
+
+# Configures this workflow to run every time release is created
+on:
+  release:
+    types: [created]
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cdoc2-server-liquibase
+  #IMAGE_NAME: ${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/cdoc2-put-server:${TAG}-${GITHUB_SHA}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${TAG}-${GITHUB_SHA}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: server-db/src/main/resources/db
+          #file: server-db/src/main/resources/db/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          #subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${REGISTRY}/${GITHUB_REPOSITORY_OWNER}/${IMAGE_NAME}:${TAG}-${GITHUB_SHA}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.actor }}/${{ env.IMAGE_NAME }}
+          images:  ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -57,7 +57,7 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           #subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-name: ${{ github.actor }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -49,7 +49,7 @@ jobs:
           context: server-db/src/main/resources/db
           #file: server-db/src/main/resources/db/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ See [getting-started.md](getting-started.md) and [admin-guide.md](admin-guide.md
 
 Download `cdoc2-put-server` and `cdoc2-get-server` images from [open-eid Container registry](https://github.com/orgs/open-eid/packages?ecosystem=container)
 
-[ghcr.io login](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
+* See [cdoc2-gatling-tests/setup-load-testing](https://github.com/open-eid/cdoc2-gatling-tests/tree/master/setup-load-testing) for `docker run` examples 
+* See [cdoc2-java-ref-impl/test/config/server/docker-compose.yml](https://github.com/open-eid/cdoc2-java-ref-impl/blob/master/test/test/config/server/docker-compose.yml) for `docker compose` example
 
-TODO: Configuring Docker images
+To create `cdoc2` database required by `put-server` and `get-server` see [postgres.README.md](postgres.README.md)
 
 ## Releasing and versioning
 

--- a/postgres.README.md
+++ b/postgres.README.md
@@ -11,16 +11,27 @@ docker stop cdoc2-psql
 
 ## Create cdoc2 database
 
-Download `cdoc2-server-liquibase` image (version must match server version) that contains liquibase changeset files
+Download [cdoc2-server-liquibase](https://github.com/orgs/open-eid/packages?ecosystem=container) image 
+(version must match server version) that contains liquibase changeset files
 specific to server version and create a `cdoc2` database. If database is running inside Docker, then
 `--link` is required, so that liquibase container can connect to it.
 ```
+docker run --rm --link cdoc2-psql \
+  --env DB_URL=jdbc:postgresql://cdoc2-psql/cdoc2 \
+  --env DB_PASSWORD=secret \
+  --env DB_USER=postgres \
+  ghcr.io/jann0k/cdoc2-server-liquibase:v1.4.0-liquibase.4-2bf479fd63cdf4c7277fcbef799e3da801cf741f
+```
+
+or use standard liquibase command options:
+
+```
 docker run --link cdoc2-psql \
 ghcr.io/jann0k/cdoc2-server-liquibase:v1.4.0-liquibase.4-2bf479fd63cdf4c7277fcbef799e3da801cf741f \
---url jdbc:postgresql://cdoc2-psql/cdoc2 \
---username=postgres \
---password=secret \
---defaultsFile=liquibase.properties \
+  --url jdbc:postgresql://cdoc2-psql/cdoc2 \
+  --username=postgres \
+  --password=secret \
+  --defaultsFile=liquibase.properties \
 update
 ```
 

--- a/postgres.README.md
+++ b/postgres.README.md
@@ -1,4 +1,4 @@
-Create postgres instance inside docker
+## Create postgres instance inside docker
 
 ```
 docker run --name cdoc2-psql -p 5432:5432 -e POSTGRES_DB=cdoc2 -e POSTGRES_PASSWORD=secret -d postgres
@@ -7,3 +7,23 @@ docker start cdoc2-psql
 docker stop cdoc2-psql
 ```
 #docker rm cdoc2-psql
+
+
+## Create cdoc2 database
+
+Download `cdoc2-server-liquibase` image (version must match server version) that contains liquibase changeset files
+specific to server version and create a `cdoc2` database. If database is running inside Docker, then
+`--link` is required, so that liquibase container can connect to it.
+```
+docker run --link cdoc2-psql \
+ghcr.io/jann0k/cdoc2-server-liquibase:v1.4.0-liquibase.4-2bf479fd63cdf4c7277fcbef799e3da801cf741f \
+--url jdbc:postgresql://cdoc2-psql/cdoc2 \
+--username=postgres \
+--password=secret \
+--defaultsFile=liquibase.properties \
+update
+```
+
+Can also be used to update DB running in other host by changing `--url`, `--username` and `--password` parameters.
+
+More info https://hub.docker.com/r/liquibase/liquibase

--- a/postgres.README.md
+++ b/postgres.README.md
@@ -26,7 +26,7 @@ docker run --rm --link cdoc2-psql \
 or use standard liquibase command options:
 
 ```
-docker run --link cdoc2-psql \
+docker run --rm --link cdoc2-psql \
 ghcr.io/jann0k/cdoc2-server-liquibase:v1.4.0-liquibase.4-2bf479fd63cdf4c7277fcbef799e3da801cf741f \
   --url jdbc:postgresql://cdoc2-psql/cdoc2 \
   --username=postgres \
@@ -35,6 +35,7 @@ ghcr.io/jann0k/cdoc2-server-liquibase:v1.4.0-liquibase.4-2bf479fd63cdf4c7277fcbe
 update
 ```
 
-Can also be used to update DB running in other host by changing `--url`, `--username` and `--password` parameters.
+Can also be used to update DB running in other host by changing `--url`, `--username` and `--password` parameters. 
+Then `--link` is not required.
 
 More info https://hub.docker.com/r/liquibase/liquibase

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -1,4 +1,4 @@
-# by default use docker.io as Docker registry, ovewrite with
+# by default use docker.io as Docker registry, overwrite with
 # --build-arg LIQUIBASE_IMAGE=custom.registry.io:8500/liquibase/liquibase
 ARG LIQUIBASE_IMAGE=docker.io/liquibase/liquibase:4.29.2
 FROM $LIQUIBASE_IMAGE

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -1,5 +1,5 @@
-# this file is used to build a docker image for upgrading the database in RIA infra
-FROM nexus.riaint.ee:8500/liquibase/liquibase
+# TODO: support for multiple registries
+FROM liquibase/liquibase
 
 WORKDIR /liquibase/changelog
 

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: support for multiple registries
-FROM liquibase/liquibase
+FROM liquibase/liquibase:latest
 
 WORKDIR /liquibase/changelog
 

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -2,6 +2,7 @@
 # --build-arg LIQUIBASE_IMAGE=custom.registry.io:8500/liquibase/liquibase
 ARG LIQUIBASE_IMAGE=docker.io/liquibase/liquibase:4.29.2
 FROM $LIQUIBASE_IMAGE
+USER liquibase
 
 WORKDIR /liquibase/changelog
 

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -1,5 +1,7 @@
-# TODO: support for multiple registries
-FROM liquibase/liquibase:4.29.2
+# by default use docker.io as Docker registry, ovewrite with
+# --build-arg LIQUIBASE_IMAGE=custom.registry.io:8500/liquibase/liquibase
+ARG LIQUIBASE_IMAGE=docker.io/liquibase/liquibase:4.29.2
+FROM $LIQUIBASE_IMAGE
 
 WORKDIR /liquibase/changelog
 

--- a/server-db/src/main/resources/db/Dockerfile
+++ b/server-db/src/main/resources/db/Dockerfile
@@ -1,5 +1,5 @@
 # TODO: support for multiple registries
-FROM liquibase/liquibase:latest
+FROM liquibase/liquibase:4.29.2
 
 WORKDIR /liquibase/changelog
 


### PR DESCRIPTION
RM-3802
* Built images available here: https://github.com/jann0k/cdoc2-capsule-server/pkgs/container/cdoc2-server-liquibase
* Usage https://github.com/jann0k/cdoc2-capsule-server/blob/ga_release_liquibase_docker/postgres.README.md
* LIQUIBASE_IMAGE base image can be overwritten with --build-arg

