### PR TITLE
Fix GH workflow for maven deploy

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -53,11 +53,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          #subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+# Broken: generates images with sha256, that fail to start with "unsupported media type application/vnd.oci.empty.v1+json"
+#      - name: Generate artifact attestation
+#        uses: actions/attest-build-provenance@v1
+#        with:
+#          #subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+#          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+#          subject-digest: ${{ steps.push.outputs.digest }}
+#          push-to-registry: true
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -23,9 +23,17 @@ jobs:
           distribution: 'temurin'
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+# Maven versioning is broken in so many ways (Maven is older than git). In semver you want to increase version only when there
+# are changes in module. Maven forces to change submodule version even when only change was main pom version change
+# Here: deploy for each submodule is necessary
+# to deploy submodules even when main module didn't change
       - name: Publish to GitHub Packages Apache Maven
         run: |
           mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f cdoc2-shared-crypto deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f server-openapi deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f server-db deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f server-common deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
           mvn -f put-server deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
           mvn -f get-server deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
         env:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -24,7 +24,10 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Publish to GitHub Packages Apache Maven
-        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        run: |
+          mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f put-server deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
+          mvn -f get-server deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -30,6 +30,7 @@ jobs:
           mvn -f get-server deploy -Dmaven.test.skip=true -s $GITHUB_WORKSPACE/settings.xml
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          MAVEN_REPO: open-eid/cdoc2-capsule-server # maven repo to download dependencies
 
       # test if username and password are correct (may still fail if no write access or wrong package name)
       - name: Log in to the Container registry

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,16 +20,26 @@ env:
 jobs:
   fork_setup:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
+
     outputs:
       base_repo: ${{ steps.base_repo.outputs.name }}
       is_fork: ${{ steps.is_fork.outputs.is_fork }}
 
     steps:
       - id: base_repo
-        run: echo "name=${{github.event.pull_request.base.repo.full_name}}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }} ]; then
+            echo "name=${{github.event.pull_request.base.repo.full_name}}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ github.event.repo.name }}" >> "$GITHUB_OUTPUT"
+          fi
       - id: is_fork
-        run: echo "is_fork=true" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }} ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     runs-on: ubuntu-latest
@@ -49,9 +59,9 @@ jobs:
       - name: Build with Maven
         run: |
           echo "Debug env vars: is_fork=$IS_FORK base_repo=$BASE_REPO MAVEN_REPO=$MAVEN_REPO"
-          mvn help:active-profiles
-          echo "Using Maven repo=$(mvn help:evaluate -Dexpression=github_ci.maven_repo -q -DforceStdout)"
-          mvn -B verify
+          mvn help:active-profiles --file cdoc2-server/
+          echo "Using Maven repo=$(mvn help:evaluate --file cdoc2-server/ -Dexpression=github_ci.maven_repo -q -DforceStdout)"
+          mvn -B verify --file cdoc2-server/pom.xml
         env:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
           IS_FORK: ${{needs.fork_setup.outputs.is_fork}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Build with Maven
         run: |
           echo "Debug env vars: is_fork=$IS_FORK base_repo=$BASE_REPO MAVEN_REPO=$MAVEN_REPO"
-          mvn help:active-profiles --file cdoc2-server/
+          mvn help:active-profiles
           echo "Using Maven repo=$(mvn help:evaluate --file cdoc2-server/ -Dexpression=github_ci.maven_repo -q -DforceStdout)"
-          mvn -B verify --file cdoc2-server/pom.xml
+          mvn -B verify
         env:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
           IS_FORK: ${{needs.fork_setup.outputs.is_fork}}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -60,13 +60,13 @@ jobs:
         run: |
           echo "Debug env vars: is_fork=$IS_FORK base_repo=$BASE_REPO MAVEN_REPO=$MAVEN_REPO"
           mvn help:active-profiles
-          echo "Using Maven repo=$(mvn help:evaluate --file cdoc2-server/ -Dexpression=github_ci.maven_repo -q -DforceStdout)"
+          echo "Using Maven repo=$(mvn help:evaluate -Dexpression=github_ci.maven_repo -q -DforceStdout)"
           mvn -B verify
         env:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
           IS_FORK: ${{needs.fork_setup.outputs.is_fork}}
           BASE_REPO: ${{needs.fork_setup.outputs.base_repo}}
-          MAVEN_REPO: ${{vars.MAVEN_REPO}}
+          MAVEN_REPO: ${{vars.MAVEN_REPO}} # set as repository variable: open-eid/cdoc2-capsule-server
 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,6 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
           IS_FORK: ${{needs.fork_setup.outputs.is_fork}}
           BASE_REPO: ${{needs.fork_setup.outputs.base_repo}}
+          MAVEN_REPO: ${{vars.MAVEN_REPO}}
 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/get-server/pom.xml
+++ b/get-server/pom.xml
@@ -467,7 +467,7 @@
 				</executions>
 				<configuration>
 					<failIfNotMatch>false</failIfNotMatch>
-					<userProperty>true</userProperty>
+					<userProperty>false</userProperty>
 					<!--skip>true</skip-->
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
 				</executions>
 				<configuration>
 					<failIfNotMatch>false</failIfNotMatch>
-					<userProperty>true</userProperty>
+					<userProperty>false</userProperty>
 					<!--skip>true</skip-->
 				</configuration>
 			</plugin>

--- a/put-server/pom.xml
+++ b/put-server/pom.xml
@@ -464,7 +464,7 @@
 				</executions>
 				<configuration>
 					<failIfNotMatch>false</failIfNotMatch>
-					<userProperty>true</userProperty>
+					<userProperty>false</userProperty>
 					<!--skip>true</skip-->
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Last Maven deploy for release v1.4.1 didn't deploy Maven artificats:
```
[INFO] ee.cyber.cdoc2:cdoc2-server-db:jar:2.2.0 does not exist
[INFO] 
[INFO] --- maven-deploy-plugin:3.1.3:deploy (default-deploy) @ cdoc2-server-db ---
[INFO] Skipping artifact deployment
```
* fix maven deploy on release
* disable attestation generation for cdoc2-server-liquibase images (generates broken images)
* try to fix building for push (builds not triggered for push currently)


